### PR TITLE
Note about /usr/local/lib and ldconfig

### DIFF
--- a/content/en/docs/Getting started/installation.md
+++ b/content/en/docs/Getting started/installation.md
@@ -39,7 +39,7 @@ You can download built binary from [GitHub Release Page](https://github.com/mimi
 
 *mimium-vx.x.x-Darwin.zip* is for macOS, and *mimium-vx.x.x-Linux.zip* is for Linux.
 
-After finished downloading and extracting zip files, copy `mimium` inside `bin` folder into `/usr/local/bin`, all files inside `lib` into `/usr/local/lib`.
+After finished downloading and extracting zip files, copy `mimium` inside `bin` folder into `/usr/local/bin`, all files inside `lib` into `/usr/local/lib`. Note that the directory `/usr/local/lib` is not in library path by default, so don't forget to add this directory to `/etc/ld.so.conf.d/` and run `ldconfig` as root.
 
 ## Build from source manually
 

--- a/content/en/docs/Getting started/installation.md
+++ b/content/en/docs/Getting started/installation.md
@@ -39,7 +39,7 @@ You can download built binary from [GitHub Release Page](https://github.com/mimi
 
 *mimium-vx.x.x-Darwin.zip* is for macOS, and *mimium-vx.x.x-Linux.zip* is for Linux.
 
-After finished downloading and extracting zip files, copy `mimium` inside `bin` folder into `/usr/local/bin`, all files inside `lib` into `/usr/local/lib`. Note that the directory `/usr/local/lib` is not in library path by default, so don't forget to add this directory to `/etc/ld.so.conf.d/` and run `ldconfig` as root.
+After finished downloading and extracting zip files, copy `mimium` inside `bin` folder into `/usr/local/bin`, all files inside `lib` into `/usr/local/lib`. On GNU/Linux, note that the directory `/usr/local/lib` is not in library path by default, so don't forget to add this directory to `/etc/ld.so.conf.d/` and run `ldconfig` as root.
 
 ## Build from source manually
 

--- a/content/ja/docs/Getting started/installation.md
+++ b/content/ja/docs/Getting started/installation.md
@@ -34,7 +34,7 @@ mimiumのビルド済みバイナリを[Github Release Page](https://github.com/
 
 *mimium-vx.x.x-Darwin.zip* がmacOS用、 *mimium-vx.x.x-Linux.zip* がLinux用です。
 
-ダウンロードとzip展開が終わったら、`bin`フォルダの中にある`mimium`プログラムを`/usr/local/mimium`に、`lib`フォルダにあるファイルすべてを`/usr/local/lib`にコピー/移動/シンボリックリンクを貼るのいずれかを行ってください。GNU/Linuxにおいてはその後、`/usr/local/lib`を`/etc/ld.so.conf.d/`配下のファイルに追記し、`ldconfig`をroot権限で実行してください。
+ダウンロードとzip展開が終わったら、`bin`フォルダの中にある`mimium`プログラムを`/usr/local/mimium`に、`lib`フォルダにあるファイルすべてを`/usr/local/lib`にコピー/移動/シンボリックリンクを貼るのいずれかを行ってください。GNU/Linuxにおいては`/usr/local/lib`はデフォルトで動的リンクのライブラリパスに入っていないので、`/usr/local/lib`を`/etc/ld.so.conf.d/`配下のファイルに追記し、`ldconfig`をroot権限で実行してください。
 
 ## ソースからビルドする
 

--- a/content/ja/docs/Getting started/installation.md
+++ b/content/ja/docs/Getting started/installation.md
@@ -34,7 +34,7 @@ mimiumのビルド済みバイナリを[Github Release Page](https://github.com/
 
 *mimium-vx.x.x-Darwin.zip* がmacOS用、 *mimium-vx.x.x-Linux.zip* がLinux用です。
 
-ダウンロードとzip展開が終わったら、`bin`フォルダの中にある`mimium`プログラムを`/usr/local/mimium`に、`lib`フォルダにあるファイルすべてを`/usr/local/lib`にコピー/移動/シンボリックリンクを貼るのいずれかを行ってください。
+ダウンロードとzip展開が終わったら、`bin`フォルダの中にある`mimium`プログラムを`/usr/local/mimium`に、`lib`フォルダにあるファイルすべてを`/usr/local/lib`にコピー/移動/シンボリックリンクを貼るのいずれかを行ってください。その後`/usr/local/lib`を`/etc/ld.so.conf.d/`配下のファイルに追記し、`ldconfig`をroot権限で実行してください。
 
 ## ソースからビルドする
 

--- a/content/ja/docs/Getting started/installation.md
+++ b/content/ja/docs/Getting started/installation.md
@@ -34,7 +34,7 @@ mimiumのビルド済みバイナリを[Github Release Page](https://github.com/
 
 *mimium-vx.x.x-Darwin.zip* がmacOS用、 *mimium-vx.x.x-Linux.zip* がLinux用です。
 
-ダウンロードとzip展開が終わったら、`bin`フォルダの中にある`mimium`プログラムを`/usr/local/mimium`に、`lib`フォルダにあるファイルすべてを`/usr/local/lib`にコピー/移動/シンボリックリンクを貼るのいずれかを行ってください。その後`/usr/local/lib`を`/etc/ld.so.conf.d/`配下のファイルに追記し、`ldconfig`をroot権限で実行してください。
+ダウンロードとzip展開が終わったら、`bin`フォルダの中にある`mimium`プログラムを`/usr/local/mimium`に、`lib`フォルダにあるファイルすべてを`/usr/local/lib`にコピー/移動/シンボリックリンクを貼るのいずれかを行ってください。GNU/Linuxにおいてはその後、`/usr/local/lib`を`/etc/ld.so.conf.d/`配下のファイルに追記し、`ldconfig`をroot権限で実行してください。
 
 ## ソースからビルドする
 


### PR DESCRIPTION
I tried to install mimium to `/usr/local/` just now, I knew the fact that: `/usr/local/lib` is not in default ld library path. So I added this note to the documentation.