### PR TITLE
Fix terminology: 'ドメイン特化言語' is generally used in Japanese

### DIFF
--- a/content/en/docs/_index.ja.md
+++ b/content/en/docs/_index.ja.md
@@ -14,7 +14,7 @@ draft: false
 {{% /pageinfo %}}
 
 
-mimium（*MInimal-Musical-medIUM*）は、音楽やサウンドを表現／生成するための領域特殊性プログラミング言語です。
+mimium（*MInimal-Musical-medIUM*）は、音楽やサウンドを表現／生成するためのドメイン特化プログラミング言語です。
 
 この言語を使うと、あなたは簡単な記述やLLVMによるハイパフォーマンス力で低レベルオーディオ処理を書くことができます。
 


### PR DESCRIPTION
For the phrase `domain-specific language`, it is traditionally translated as `ドメイン固有言語` or `ドメイン特化言語` in Japanese. cf. [the article in Wikipedia for "Domain-specific Languages"](https://ja.wikipedia.org/wiki/%E3%83%89%E3%83%A1%E3%82%A4%E3%83%B3%E5%9B%BA%E6%9C%89%E8%A8%80%E8%AA%9E#:~:text=%E3%83%89%E3%83%A1%E3%82%A4%E3%83%B3%E7%89%B9%E5%8C%96%E8%A8%80%E8%AA%9E%EF%BC%88%E3%83%89%E3%83%A1%E3%82%A4%E3%83%B3,%E3%81%9F%E3%82%B3%E3%83%B3%E3%83%94%E3%83%A5%E3%83%BC%E3%82%BF%E8%A8%80%E8%AA%9E%E3%81%A7%E3%81%82%E3%82%8B%E3%80%82)

ちょっとした修正ではあるのですが！