### PR TITLE
fix typo in the code example using the metro function

### DIFF
--- a/content/en/docs/user_guide/special-features.en.md
+++ b/content/en/docs/user_guide/special-features.en.md
@@ -78,7 +78,7 @@ fn counter(){
 }
 let myfreq:()->float = metro(1.0*samplerate ,counter);
 fn dsp(){
-    let r = sinwave(myfreq,0.0) * 0.5
+    let r = sinwave(myfreq(),0.0) * 0.5
     (r,r)
 }
 ```

--- a/content/en/docs/user_guide/special-features.ja.md
+++ b/content/en/docs/user_guide/special-features.ja.md
@@ -83,7 +83,7 @@ fn counter(){
 }
 let myfreq:()->float = metro(1.0*samplerate ,counter);
 fn dsp(){
-    let r = sinwave(myfreq,0.0) * 0.5
+    let r = sinwave(myfreq(),0.0) * 0.5
     (r,r)
 }
 ```


### PR DESCRIPTION
this PR fixes the typo in the [doc](https://mimium.org/ja/docs/user_guide/special-features/) so that it would work with mimium-cli 2.2.7.
